### PR TITLE
adds requested additional ssh key info in OS group tabs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -30,7 +30,7 @@ release = 'v1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-'sphinx_toolbox.collapse',
+'sphinx_toolbox.collapse','sphinx_tabs.tabs'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/starting.rst
+++ b/source/starting.rst
@@ -1,3 +1,17 @@
+.. raw:: html
+
+    <style> 
+        .red {color:red;} 
+        .black {color:black; text-shadow:none;} 
+        .gold {color:#fecb2f;}
+    </style>
+
+.. role:: red
+
+.. role:: black
+
+.. role:: gold
+
 Getting started
 ---------------
 
@@ -10,15 +24,62 @@ If you already have a general MIT account then getting access to subMIT is easy.
 
 You might be prompted for not being authorized to access the portal. Please, follow the instructions on the screen.
 
-If you are not familiar with ssh keys, generating keys is a straightforward process. To generate keys on your machine use the following command (chose the defaults when being prompted):
+If you are not familiar with ssh keys, generating keys is a straightforward process. 
+
+
+.. tabs::
+
+   .. group-tab:: :gold:`Mac OS`
+
+      :black:`Open the Terminal application.`
+      :black:`This can be done by clicking on Lanuchpad or hitting F4, and then typing "terminal" followed by the Return key.`
+
+   .. group-tab:: :gold:`Windows`
+
+      :black:`We recommend you install & use Windows Subsystem for Linux.  If you do not wish to at this time, you may follow these directions to generate keys natively in Windows...`
+
+      :black:`Click in the Start Menu search bar (next to the Windows icon), then type "command prompt" followed by the Enter key.`
+
+
+
+To generate keys on your machine use the following command (chose the defaults when being prompted):
 
 .. code-block:: sh
 
    ssh-keygen -t rsa
 
-This should create both a private and a public key (``id_rsa``, the private key, and ``id_rsa.pub``, the public key) in your ``.ssh`` directory. Simply paste the contents of the public key (``id_rsa.pub``) into the submit portal link above and you are ready. The private key is like your password and should never be exposed to anybody. Please do not paste this into the subMIT website; if you do you should re-create your keys by running the ``ssh-keygen`` command again.
+This should create both a private and a public key (``id_rsa``, the private key, and ``id_rsa.pub``, the public key) in your ``.ssh`` directory. 
+
+.. tabs::
+
+   .. group-tab:: :gold:`Mac OS`
+
+      :black:`In the output on your screen you will see a line specifying the path to your public key, such as "Your public key has been saved in /Users/[username]/.ssh/id_rsa.pub".`
+      :black:`To copy your public key, run the following command using the path to your public key`
+
+      .. code-block:: console
+
+         cat /Users/[username]/.ssh/id_rsa.pub | pbcopy
+      
+      :black:`Or simply open the public key file in your favorite text editor and highlight & copy the text.`
+
+   .. group-tab:: :gold:`Windows`
+
+      :black:`In the output on your screen you will see a line specifying the path to your public key, such as "Your public key has been saved in C:\\Users\\[username]/.ssh/id_rsa.pub"`
+      :black:`To copy your public key, run the following command using the path to your public key`
+      
+      .. code-block:: console
+
+         clip < C:\Users\[username]/.ssh/id_rsa.pub
+      
+      :black:`Or simply open the public key file in your favorite text editor and highlight & copy the text.`
+
+
+Simply paste the contents of the public key (``id_rsa.pub``) into the submit portal link above and you are ready. The private key is like your password and should never be exposed to anybody. Please do not paste this into the subMIT website; if you do you should re-create your keys by running the ``ssh-keygen`` command again.
 
 We recommend that you use the standard name (as prompted by ``ssh-keygen``) for the keys, as this will make the process easier. Some advanced users may want to create differently named keys within their ``.ssh`` directory, as they may wish to keep separate keys for separate machines. If you do this, please remember to either create the appropriate configuration within ``.ssh/config``, or log in with ``ssh -i /path/to/identity/file``.
+
+
 
 Login and basic areas
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds info requested by user: how to get to command line & copy on Mac & Windows.

Temporary workaround: font colors are manually set for the tabs since the theme renders tabs unreadable (white text on white background).  Ideally, the theme will be updated and this workaround removed in the future.